### PR TITLE
Update data structures to use double precision vectors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 org.gradle.caching=true
 org.gradle.parallel=true
 
-packedVersion=1.1.0
+packedVersion=1.1.1

--- a/packed-core/src/main/kotlin/net/radstevee/packed/core/item/ItemModel.kt
+++ b/packed-core/src/main/kotlin/net/radstevee/packed/core/item/ItemModel.kt
@@ -8,9 +8,8 @@ import net.radstevee.packed.core.key.Key
 import net.radstevee.packed.core.pack.ResourcePack
 import net.radstevee.packed.core.pack.ResourcePackElement
 import net.radstevee.packed.core.packedLogger
-import net.radstevee.packed.core.util.Mat2x2i
+import net.radstevee.packed.core.util.Mat2x2d
 import net.radstevee.packed.core.util.Vec3d
-import net.radstevee.packed.core.util.Vec3i
 import java.io.File
 import kotlin.properties.Delegates
 
@@ -292,8 +291,8 @@ public data class ItemModelDisplayPosition(
 }
 
 public data class Cube(
-  public val from: Vec3i,
-  public val to: Vec3i,
+  public val from: Vec3d,
+  public val to: Vec3d,
   public val rotation: CubeRotation?,
   public val shade: Boolean,
   public val faces: CubeFaces?,
@@ -302,10 +301,10 @@ public data class Cube(
     public val CODEC: Codec<Cube> = RecordCodecBuilder.create { instance ->
       instance
         .group(
-          Vec3i.CODEC
+          Vec3d.CODEC
             .fieldOf("from")
             .forGetter(Cube::from),
-          Vec3i.CODEC
+          Vec3d.CODEC
             .fieldOf("to")
             .forGetter(Cube::to),
           CubeRotation.CODEC
@@ -322,8 +321,8 @@ public data class Cube(
   }
 
   public class Builder {
-    public var from: Vec3i? = null
-    public var to: Vec3i? = null
+    public var from: Vec3d? = null
+    public var to: Vec3d? = null
     public var rotation: CubeRotation? = null
     public var shade: Boolean = true
     public var faces: CubeFaces? = null
@@ -407,7 +406,7 @@ public data class CubeFaces(
 }
 
 public data class CubeFace(
-  public val uv: Mat2x2i?,
+  public val uv: Mat2x2d?,
   public val texture: String?,
   public val cullFace: String?,
   public val rotation: Int?,
@@ -417,7 +416,7 @@ public data class CubeFace(
     public val CODEC: Codec<CubeFace> = RecordCodecBuilder.create { instance ->
       instance
         .group(
-          Mat2x2i.CODEC
+          Mat2x2d.CODEC
             .nullableFieldOf("uv")
             .forGetter(CubeFace::uv),
           Codec.STRING
@@ -437,7 +436,7 @@ public data class CubeFace(
   }
 
   public class Builder {
-    public var uv: Mat2x2i? = null
+    public var uv: Mat2x2d? = null
     public var texture: String? = null
     public var cullFace: String? = null
     public var rotation: Int? = null

--- a/packed-core/src/main/kotlin/net/radstevee/packed/core/item/ItemModel.kt
+++ b/packed-core/src/main/kotlin/net/radstevee/packed/core/item/ItemModel.kt
@@ -331,6 +331,10 @@ public data class Cube(
       faces = CubeFaces.Builder().apply(block).build()
     }
 
+    public inline fun rotation(block: CubeRotation.Builder.() -> Unit) {
+      rotation = CubeRotation.Builder().apply(block).build()
+    }
+
     public fun build(): Cube = Cube(from ?: error("cube has no starting point"), to ?: error("cube has no ending point"), rotation, shade, faces)
   }
 }

--- a/packed-core/src/main/kotlin/net/radstevee/packed/core/util/Vectors.kt
+++ b/packed-core/src/main/kotlin/net/radstevee/packed/core/util/Vectors.kt
@@ -70,15 +70,13 @@ public data class Mat2x2i(
     }
   }
 }
+
 public data class Mat2x2d(
   val x1: Double,
   val y1: Double,
   val x2: Double,
   val y2: Double,
 ) {
-
-  public constructor(x1: Number, y1: Number, x2: Number, y2: Number) : this(x1.toDouble(), y1.toDouble(), x2.toDouble(), y2.toDouble())
-
   public companion object {
     public val CODEC: Codec<Mat2x2d> = RecordCodecBuilder.create { instance ->
       instance
@@ -92,39 +90,39 @@ public data class Mat2x2d(
   }
 }
 
-/**
- * Constructs a 3-dimensional integer vector.
- */
+/** Constructs a 3-dimensional integer vector. */
 public fun vec(
   x: Int,
   y: Int,
   z: Int,
 ): Vec3i = Vec3i(x, y, z)
 
-/**
- * Constructs a 3-dimensional double vector.
- */
+/** Constructs a 3-dimensional double vector. */
 public fun vec(
   x: Double,
   y: Double,
   z: Double,
 ): Vec3d = Vec3d(x, y, z)
 
-/**
- * Constructs a 3-dimensional float vector.
- */
+/** Constructs a 3-dimensional float vector. */
 public fun vec(
   x: Float,
   y: Float,
   z: Float,
 ): Vec3f = Vec3f(x, y, z)
 
-/**
- * Constructs a 2x2-dimensional integer matrix.
- */
+/** Constructs a 2x2-dimensional integer matrix. */
 public fun mat(
   x1: Int,
   y1: Int,
   x2: Int,
   y2: Int,
 ): Mat2x2i = Mat2x2i(x1, y1, x2, y2)
+
+/** Constructs a 2x2-dimensional double matrix. */
+public fun mat(
+  x1: Double,
+  y1: Double,
+  x2: Double,
+  y2: Double
+): Mat2x2d = Mat2x2d(x1, y1, x2, y2)

--- a/packed-core/src/main/kotlin/net/radstevee/packed/core/util/Vectors.kt
+++ b/packed-core/src/main/kotlin/net/radstevee/packed/core/util/Vectors.kt
@@ -70,6 +70,24 @@ public data class Mat2x2i(
     }
   }
 }
+public data class Mat2x2d(
+  val x1: Double,
+  val y1: Double,
+  val x2: Double,
+  val y2: Double,
+) {
+  public companion object {
+    public val CODEC: Codec<Mat2x2d> = RecordCodecBuilder.create { instance ->
+      instance
+        .group(
+          Codec.DOUBLE.fieldOf("x1").forGetter(Mat2x2d::x1),
+          Codec.DOUBLE.fieldOf("y1").forGetter(Mat2x2d::y1),
+          Codec.DOUBLE.fieldOf("x2").forGetter(Mat2x2d::x2),
+          Codec.DOUBLE.fieldOf("y2").forGetter(Mat2x2d::y2),
+        ).apply(instance, ::Mat2x2d)
+    }
+  }
+}
 
 /**
  * Constructs a 3-dimensional integer vector.

--- a/packed-core/src/main/kotlin/net/radstevee/packed/core/util/Vectors.kt
+++ b/packed-core/src/main/kotlin/net/radstevee/packed/core/util/Vectors.kt
@@ -76,6 +76,9 @@ public data class Mat2x2d(
   val x2: Double,
   val y2: Double,
 ) {
+
+  public constructor(x1: Number, y1: Number, x2: Number, y2: Number) : this(x1.toDouble(), y1.toDouble(), x2.toDouble(), y2.toDouble())
+
   public companion object {
     public val CODEC: Codec<Mat2x2d> = RecordCodecBuilder.create { instance ->
       instance


### PR DESCRIPTION
Replaced `Vec3i` and `Mat2x2i` with `Vec3d` and `Mat2x2d` for greater precision in calculations. Updated codecs, constructors, and relevant usages accordingly. Bumped version to 1.1.1 to reflect these enhancements.