### PR TITLE
Feature: add min_format and max_format from 1.21.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 org.gradle.caching=true
 org.gradle.parallel=true
 
-packedVersion=1.1.3
+packedVersion=1.1.4

--- a/packed-core/src/main/kotlin/net/radstevee/packed/core/pack/ResourcePackMeta.kt
+++ b/packed-core/src/main/kotlin/net/radstevee/packed/core/pack/ResourcePackMeta.kt
@@ -19,6 +19,8 @@ import net.radstevee.packed.core.codec.nullableFieldOf
  */
 public data class Pack(
   val packFormat: Int,
+  val minFormat: Int?,
+  val maxFormat: Int?,
   val supportedFormats: SupportedFormats?,
   val description: String?,
 ) {
@@ -29,6 +31,12 @@ public data class Pack(
           Codec.INT
             .fieldOf("pack_format")
             .forGetter(Pack::packFormat),
+          Codec.INT
+            .nullableFieldOf("min_format")
+            .forGetter(Pack::minFormat),
+          Codec.INT
+            .nullableFieldOf("max_format")
+            .forGetter(Pack::maxFormat),
           SupportedFormats.CODEC
             .nullableFieldOf("supported_formats")
             .forGetter(Pack::supportedFormats),
@@ -119,9 +127,12 @@ public data class ResourcePackMeta(
     public fun create(
       format: Int,
       description: String?,
-    ): ResourcePackMeta = ResourcePackMeta(
-      Pack(format, null, description),
-      null,
-    )
+    ): ResourcePackMeta {
+      val minMax = if (format >= PackFormat.V1_21_9_TO_1_21_10) format else null
+      return ResourcePackMeta(
+        Pack(format, minMax, minMax, null, description),
+        null,
+      )
+    }
   }
 }


### PR DESCRIPTION
1.21.9 added new resource pack declaration methods with min_format and max_format. It also removes the "marked as obsolete" warning in resource packs at runtime because of this.